### PR TITLE
fix test timing issue in locker_sql_test.go

### DIFF
--- a/locker/locker_sql_test.go
+++ b/locker/locker_sql_test.go
@@ -921,8 +921,8 @@ func (s *LockerSQLTestSuite) TestWaitLockDoWithWaitCtxCloseWaitCtx() {
 	waitCtx, cancel := context.WithCancel(s.ctx)
 
 	time.AfterFunc(defaultHeartbeatInterval, func() {
-		require.NoError(t, l.Close(s.ctx))
 		cancel()
+		require.NoError(t, l.Close(s.ctx))
 	})
 
 	now := time.Now()
@@ -930,6 +930,9 @@ func (s *LockerSQLTestSuite) TestWaitLockDoWithWaitCtxCloseWaitCtx() {
 	err = locker.WaitLockDoWithWaitCtx(s.ctx, waitCtx, lockID, time.Second, func(_ context.Context) error {
 		return nil
 	})
+
+	<-l.ShutdownCtx().Done()
+
 	require.ErrorIs(t, err, context.Canceled)
 	require.ErrorContains(t, err, "wait lock")
 	require.Less(t, time.Since(now), defaultHeartbeatInterval*2+150*time.Millisecond)

--- a/locker/locker_sql_test.go
+++ b/locker/locker_sql_test.go
@@ -914,15 +914,15 @@ func (s *LockerSQLTestSuite) TestWaitLockDoWithWaitCtxCloseWaitCtx() {
 	require.NoError(t, err)
 	require.NotNil(t, locker)
 
-	l, err := locker.TryLock(s.ctx, lockID)
+	lck, err := locker.TryLock(s.ctx, lockID)
 	require.NoError(t, err)
-	require.NotNil(t, l)
+	require.NotNil(t, lck)
 
 	waitCtx, cancel := context.WithCancel(s.ctx)
 
 	time.AfterFunc(defaultHeartbeatInterval, func() {
 		cancel()
-		require.NoError(t, l.Close(s.ctx))
+		require.NoError(t, lck.Close(s.ctx))
 	})
 
 	now := time.Now()
@@ -931,7 +931,7 @@ func (s *LockerSQLTestSuite) TestWaitLockDoWithWaitCtxCloseWaitCtx() {
 		return nil
 	})
 
-	<-l.ShutdownCtx().Done()
+	<-lck.ShutdownCtx().Done()
 
 	require.ErrorIs(t, err, context.Canceled)
 	require.ErrorContains(t, err, "wait lock")


### PR DESCRIPTION
Moved require.NoError call to ensure context cancellation occurs before checking for shutdown. Added an additional check to wait for shutdown to complete, ensuring the test behaves predictably.